### PR TITLE
fix: assumption that angular is installed globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 all: build
 
 deps:
-	@echo "installing dependencies ..."	
+	@echo "installing dependencies ..."
 	@NODE_OPTIONS=--openssl-legacy-provider npm i --legacy-peer-deps
 
 build: deps
 	@echo "building ui ..."
-	@NODE_OPTIONS=--openssl-legacy-provider ng build --prod   
+	@NODE_OPTIONS=--openssl-legacy-provider npx ng build --prod
 
 
 


### PR DESCRIPTION
- The build system assumes that the user has angular installed globally on their system.
- Fix: use the version installed from `npm install`